### PR TITLE
Drop 'mimir-' prefix from relation names

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -12,43 +12,44 @@ source: https://github.com/canonical/mimir-worker-k8s-operator
 issues: https://github.com/canonical/mimir-worker-k8s-operator/issues
 
 provides:
-  mimir-compactor:
+  # Note: relation names match exactly Mimir's role names
+  compactor:
     interface: mimir_worker
     limit: 1
 
-  mimir-distributor:
+  distributor:
     interface: mimir_worker
     limit: 1
 
-  mimir-ingester:
+  ingester:
     interface: mimir_worker
     limit: 1
 
-  mimir-querier:
+  querier:
     interface: mimir_worker
     limit: 1
 
-  mimir-query-frontend:
+  query-frontend:
     interface: mimir_worker
     limit: 1
 
-  mimir-store-gateway:
+  store-gateway:
     interface: mimir_worker
     limit: 1
 
-  mimir-alertmanager:
+  alertmanager:
     interface: mimir_worker
     limit: 1
 
-  mimir-ruler:
+  ruler:
     interface: mimir_worker
     limit: 1
 
-  mimir-overrides-exporter:
+  overrides-exporter:
     interface: mimir_worker
     limit: 1
 
-  mimir-query-scheduler:
+  query-scheduler:
     interface: mimir_worker
     limit: 1
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -187,7 +187,16 @@ class MimirWorkerK8SOperatorCharm(CharmBase):
         self.framework.observe(self.on.update_status, self._on_update_status)
 
         self._mimir_relation_names = [
-            k for k in self.meta.provides.keys() if k.startswith("mimir-")
+            "compactor",
+            "distributor",
+            "ingester",
+            "querier",
+            "query-frontend",
+            "store-gateway",
+            "alertmanager",
+            "ruler",
+            "overrides-exporter",
+            "query-scheduler",
         ]
         for rel_name in self._mimir_relation_names:
             self.framework.observe(
@@ -276,12 +285,8 @@ class MimirWorkerK8SOperatorCharm(CharmBase):
         """Return a set of the roles Mimir worker should take on."""
         # Filter out of all possible relations those that actually are active
         active_rel_names = [k for k in self._mimir_relation_names if self.model.relations.get(k)]
-        active_roles = [
-            rel[len("mimir-") :] for rel in active_rel_names if rel.startswith("mimir-")
-        ]
-        # TODO make sure that the list of active roles is a subset of valid roles
-        #  or drop the 'mimir-' prefix from relation names
-        return active_roles or DEFAULT_ROLES
+        # Assuming relation names match exactly Mimir roles.
+        return sorted(active_rel_names) or DEFAULT_ROLES
 
     @property
     def _mimir_version(self) -> Optional[str]:

--- a/tests/scenario/test_deploy.py
+++ b/tests/scenario/test_deploy.py
@@ -17,7 +17,7 @@ def test_update_status_cannot_connect(ctx, evt):
 
 
 @pytest.mark.parametrize(
-    "roles",
+    "relations",
     (
         ["alertmanager", "compactor"],
         ["alertmanager", "distributor"],
@@ -27,15 +27,13 @@ def test_update_status_cannot_connect(ctx, evt):
         ["alertmanager", "overrides-exporter", "ruler", "store-gateway"],  # order matters
     ),
 )
-def test_pebble_ready_plan(ctx, roles):
-    mimir_relations = tuple("mimir-" + roles for roles in roles)
-
+def test_pebble_ready_plan(ctx, relations):
     expected_plan = {
         "services": {
             "mimir-worker": {
                 "override": "replace",
                 "summary": "mimir worker daemon",
-                "command": f"/bin/mimir --config.file=/etc/mimir/mimir-config.yaml -target {','.join(roles)}",
+                "command": f"/bin/mimir --config.file=/etc/mimir/mimir-config.yaml -target {','.join(relations)}",
                 "startup": "enabled",
             }
         },
@@ -53,7 +51,7 @@ def test_pebble_ready_plan(ctx, roles):
             containers=[mimir_container],
             relations=[
                 Relation(endpoint, interface="mimir_worker", remote_app_name=f"{endpoint} app")
-                for endpoint in mimir_relations
+                for endpoint in relations
             ],
         ),
     )


### PR DESCRIPTION
## Issue
Before this PR, charm code needed to add/remove the "mimir-" prefix when converting between relation names and role names.


## Solution
Have the mimir relation names match exactly Mimir roles.
