### PR TITLE
Add certificate path for charm tracing

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -51,6 +51,7 @@ logger = logging.getLogger(__name__)
 
 @trace_charm(
     tracing_endpoint="tempo_endpoint",
+    server_cert="server_cert_path",
     extra_types=[
         MimirClusterRequirer,
         KubernetesServicePatch,
@@ -298,6 +299,11 @@ class MimirWorkerK8SOperatorCharm(CharmBase):
             return self.tracing.otlp_http_endpoint()
         else:
             return None
+
+    @property
+    def server_cert_path(self) -> Optional[str]:
+        """Server certificate path for tls tracing."""
+        return MIMIR_CERT_FILE
 
 
 if __name__ == "__main__":  # pragma: nocover


### PR DESCRIPTION
## Issue
Add SSL support for charm tracing in mimir-worker.

## Testing Instructions

Full bundle - once bundle is deployed, you should see traces from mimir-worker-k8s in tempo datasource in Grafana.
```
bundle: kubernetes
applications:
  alertmanager:
    charm: alertmanager-k8s
    channel: stable
    revision: 96
    series: focal
    resources:
      alertmanager-image: 84
    scale: 1
    constraints: arch=amd64
    storage:
      data: kubernetes,1,1024M
    trust: true
  catalogue:
    charm: catalogue-k8s
    channel: stable
    revision: 33
    series: focal
    resources:
      catalogue-image: 32
    scale: 1
    options:
      description: "Canonical Observability Stack Lite, or COS Lite, is a light-weight,
        highly-integrated, \nJuju-based observability suite running on Kubernetes.\n"
      tagline: Model-driven Observability Stack deployed with a single command.
      title: Canonical Observability Stack
    constraints: arch=amd64
    trust: true
  grafana:
    charm: grafana-k8s
    channel: stable
    revision: 93
    series: focal
    resources:
      grafana-image: 62
      litestream-image: 43
    scale: 1
    constraints: arch=amd64
    storage:
      database: kubernetes,1,1024M
    trust: true
  loki:
    charm: loki-k8s
    channel: stable
    revision: 105
    series: focal
    resources:
      loki-image: 88
    scale: 1
    constraints: arch=amd64
    storage:
      active-index-directory: kubernetes,1,1024M
      loki-chunks: kubernetes,1,1024M
    trust: true
  mimir-coordinator-k8s:
    charm: local:mimir-coordinator-k8s-0
    scale: 1
    constraints: arch=amd64
    storage:
      data: kubernetes,1,1024M
    trust: true
  mimir-worker-k8s:
    charm: local:mimir-worker-k8s-0
    scale: 1
    constraints: arch=amd64
    storage:
      data: kubernetes,1,1024M
    trust: true
  prometheus:
    charm: prometheus-k8s
    channel: stable
    revision: 159
    series: focal
    resources:
      prometheus-image: 134
    scale: 1
    constraints: arch=amd64
    storage:
      database: kubernetes,1,1024M
    trust: true
  self-signed-certificates:
    charm: self-signed-certificates
    channel: stable
    revision: 57
    scale: 1
    constraints: arch=amd64
  tempo-k8s:
    charm: tempo-k8s
    channel: candidate
    revision: 22
    resources:
      tempo-image: 14
    scale: 1
    constraints: arch=amd64
    storage:
      data: kubernetes,1,1024M
  traefik:
    charm: traefik-k8s
    channel: stable
    revision: 166
    series: focal
    resources:
      traefik-image: 155
    scale: 1
    constraints: arch=amd64
    storage:
      configurations: kubernetes,1,1024M
    trust: true
relations:
- - mimir-coordinator-k8s:certificates
  - self-signed-certificates:certificates
- - mimir-coordinator-k8s:tracing
  - tempo-k8s:tracing
- - traefik:ingress-per-unit
  - prometheus:ingress
- - traefik:ingress-per-unit
  - loki:ingress
- - traefik:traefik-route
  - grafana:ingress
- - traefik:ingress
  - alertmanager:ingress
- - prometheus:alertmanager
  - alertmanager:alerting
- - grafana:grafana-source
  - prometheus:grafana-source
- - grafana:grafana-source
  - loki:grafana-source
- - grafana:grafana-source
  - alertmanager:grafana-source
- - loki:alertmanager
  - alertmanager:alerting
- - prometheus:metrics-endpoint
  - traefik:metrics-endpoint
- - prometheus:metrics-endpoint
  - alertmanager:self-metrics-endpoint
- - prometheus:metrics-endpoint
  - loki:metrics-endpoint
- - prometheus:metrics-endpoint
  - grafana:metrics-endpoint
- - grafana:grafana-dashboard
  - loki:grafana-dashboard
- - grafana:grafana-dashboard
  - prometheus:grafana-dashboard
- - grafana:grafana-dashboard
  - alertmanager:grafana-dashboard
- - catalogue:ingress
  - traefik:ingress
- - catalogue:catalogue
  - grafana:catalogue
- - catalogue:catalogue
  - prometheus:catalogue
- - catalogue:catalogue
  - alertmanager:catalogue
- - tempo-k8s:grafana-source
  - grafana:grafana-source
- - tempo-k8s:tracing
  - mimir-worker-k8s:tracing
- - mimir-coordinator-k8s:mimir-cluster
  - mimir-worker-k8s:mimir-cluster
```
