### PR TITLE
fixed bug with overlapping data and recovery storage dir

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -26,6 +26,9 @@ storage:
   data:
     type: filesystem
     description: Common storage point for all components
+  recovery-data:
+    type: filesystem
+    description: Recovery data root for all components
 
 # The Mimir coordinator has a hardcoded dependency on the mount location,
 # and it relies on this path to generate the configuration.
@@ -37,6 +40,8 @@ containers:
     mounts:
       - storage: data
         location: /data
+      - storage: recovery-data
+        location: /recovery-data
 
 resources:
   mimir-image:


### PR DESCRIPTION
Fixes #24 

Tandem PR: https://github.com/canonical/mimir-coordinator-k8s-operator/pull/32

Testing instructions:

```
bundle: kubernetes                           
applications:                                
  coord:                                     
    charm: local:mimir-coordinator-k8s-0     
    scale: 1                                 
    constraints: arch=amd64                  
    storage:                                 
      data: kubernetes,1,1024M               
  worker:                                   
    charm: local:mimir-worker-k8s-0          
    scale: 1                                 
    options:                                 
      all: true                              
    constraints: arch=amd64                  
    storage:                                 
      data: kubernetes,1,1024M               
      recovery-data: kubernetes,1,1024M      
relations:                                   
- - coord:mimir-cluster                      
  - worker:mimir-cluster                    
```

And watch it go green.