### PR TITLE
fix: use set_ports instead of open_port

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -64,7 +64,7 @@ class MimirWorkerK8SOperatorCharm(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
         self._container = self.unit.get_container(self._name)
-        self.unit.open_port(protocol="tcp", port=8080)
+        self.unit.set_ports(8080)
 
         self.topology = JujuTopology.from_charm(self)
         self.mimir_cluster = MimirClusterRequirer(self)


### PR DESCRIPTION
## Issue

`open_port` doesn't close ports; if the port changes on upgrades, the previous one isn't closed.

## Solution

Use `set_ports` instead, as documented [here](https://github.com/canonical/operator/blob/ab239e1156bd206f9825b5be96fbf83121489fee/ops/model.py#L699).