### PR TITLE
fix: use leader units in integration tests, not unit 0; add trust

### DIFF
--- a/tests/integration/test_charm_ha.py
+++ b/tests/integration/test_charm_ha.py
@@ -32,11 +32,11 @@ async def test_build_and_deploy(ops_test: OpsTest):
     assert ops_test.model is not None  # for pyright
     await asyncio.gather(
         ops_test.model.deploy("mimir-coordinator-k8s", "mimir", channel="latest/edge"),
-        ops_test.model.deploy("prometheus-k8s", "prometheus", channel="latest/edge"),
-        ops_test.model.deploy("loki-k8s", "loki", channel="latest/edge"),
-        ops_test.model.deploy("grafana-k8s", "grafana", channel="latest/edge"),
+        ops_test.model.deploy("prometheus-k8s", "prometheus", channel="latest/edge", trust=True),
+        ops_test.model.deploy("loki-k8s", "loki", channel="latest/edge", trust=True),
+        ops_test.model.deploy("grafana-k8s", "grafana", channel="latest/edge", trust=True),
         ops_test.model.deploy("grafana-agent-k8s", "agent", channel="latest/edge"),
-        ops_test.model.deploy("traefik-k8s", "traefik", channel="latest/edge"),
+        ops_test.model.deploy("traefik-k8s", "traefik", channel="latest/edge", trust=True),
         # Deploy and configure Minio and S3
         # Secret must be at least 8 characters: https://github.com/canonical/minio-operator/issues/137
         ops_test.model.deploy(

--- a/tests/integration/test_charm_ha_scaled.py
+++ b/tests/integration/test_charm_ha_scaled.py
@@ -31,11 +31,11 @@ async def test_build_and_deploy(ops_test: OpsTest):
     assert ops_test.model is not None  # for pyright
     await asyncio.gather(
         ops_test.model.deploy("mimir-coordinator-k8s", "mimir", channel="latest/edge"),
-        ops_test.model.deploy("prometheus-k8s", "prometheus", channel="latest/edge"),
-        ops_test.model.deploy("loki-k8s", "loki", channel="latest/edge"),
-        ops_test.model.deploy("grafana-k8s", "grafana", channel="latest/edge"),
+        ops_test.model.deploy("prometheus-k8s", "prometheus", channel="latest/edge", trust=True),
+        ops_test.model.deploy("loki-k8s", "loki", channel="latest/edge", trust=True),
+        ops_test.model.deploy("grafana-k8s", "grafana", channel="latest/edge", trust=True),
         ops_test.model.deploy("grafana-agent-k8s", "agent", channel="latest/edge"),
-        ops_test.model.deploy("traefik-k8s", "traefik", channel="latest/edge"),
+        ops_test.model.deploy("traefik-k8s", "traefik", channel="latest/edge", trust=True),
         # Deploy and configure Minio and S3
         # Secret must be at least 8 characters: https://github.com/canonical/minio-operator/issues/137
         ops_test.model.deploy(

--- a/tests/integration/test_charm_monolithic.py
+++ b/tests/integration/test_charm_monolithic.py
@@ -31,11 +31,11 @@ async def test_build_and_deploy(ops_test: OpsTest):
     assert ops_test.model is not None  # for pyright
     await asyncio.gather(
         ops_test.model.deploy("mimir-coordinator-k8s", "mimir", channel="latest/edge"),
-        ops_test.model.deploy("prometheus-k8s", "prometheus", channel="latest/edge"),
-        ops_test.model.deploy("loki-k8s", "loki", channel="latest/edge"),
-        ops_test.model.deploy("grafana-k8s", "grafana", channel="latest/edge"),
+        ops_test.model.deploy("prometheus-k8s", "prometheus", channel="latest/edge", trust=True),
+        ops_test.model.deploy("loki-k8s", "loki", channel="latest/edge", trust=True),
+        ops_test.model.deploy("grafana-k8s", "grafana", channel="latest/edge", trust=True),
         ops_test.model.deploy("grafana-agent-k8s", "agent", channel="latest/edge"),
-        ops_test.model.deploy("traefik-k8s", "traefik", channel="latest/edge"),
+        ops_test.model.deploy("traefik-k8s", "traefik", channel="latest/edge", trust=True),
         # Deploy and configure Minio and S3
         # Secret must be at least 8 characters: https://github.com/canonical/minio-operator/issues/137
         ops_test.model.deploy(


### PR DESCRIPTION
Based on flaky CI fixes from [mimir-coordinator](https://github.com/canonical/mimir-coordinator-k8s-operator/pull/70), this PR:
* fixes an intermittent issue where integration CI would try to access the leader unit of a charm at unit/0 when it might be unit/0
* fixes a problem where, when RBAC is enabled, the integration CI will fail to deploy because some charms require elevated permissions

This PR currently fails integration tests for unrelated reasons that will be investigated separately.  