### PR TITLE
fix: increase the timeout for charm_ha_scale integration test

### DIFF
--- a/tests/integration/test_charm_ha_scaled.py
+++ b/tests/integration/test_charm_ha_scaled.py
@@ -120,6 +120,7 @@ async def test_integrate(ops_test: OpsTest):
             "traefik",
         ],
         status="active",
+        timeout=60 * 30,
     )
 
 


### PR DESCRIPTION
## Issue
during `charm_ha_scaled.py`'s `test_integrate`, the deployment sometimes takes longer than `wait_for_idle`'s default 10 minutes to be up and running, resulting in integration test failures.  Underpowered github runners especially contribute to this.

## Solution
Extend the timeout to 30 minutes.

## Context
-

## Testing Instructions
If CI passes, it works

## Release Notes
-

Closes #71 
Related to OPENG-2662