### PR TITLE
Add workload tracing to Mimir

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -24,11 +24,6 @@ requires:
     interface: mimir_cluster
     limit: 1
 
-  tracing:
-    interface: tracing
-    limit: 1
-    description: |
-      Enables sending traces to the tracing backend
 
 storage:
   data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ops >= 1.5.0
-cosl
+cosl>=0.0.43
 
 # Charm relation interfaces
 pydantic


### PR DESCRIPTION
## Issue
Enable sending Mimir's (workload) internal traces.

## Solution
- Configure `jaeger` env variables


## Context
https://github.com/canonical/cos-lib/pull/95

## Testing Instructions
1. Deploy Mimir HA solution with this [coordinator](https://github.com/canonical/loki-worker-k8s-operator/pull/30)
2. Deploy grafana
3. integrate `mimir:grafana-source` with `grafana`
4. You'll find mimir's workload traces