### PR TITLE
Pin minio charm in itests to "ckf-1.9/stable" track

### DIFF
--- a/tests/integration/test_charm_ha.py
+++ b/tests/integration/test_charm_ha.py
@@ -41,7 +41,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
         # Secret must be at least 8 characters: https://github.com/canonical/minio-operator/issues/137
         ops_test.model.deploy(
             "minio",
-            channel="latest/stable",
+            channel="ckf-1.9/stable",
             config={"access-key": "access", "secret-key": "secretsecret"},
         ),
         ops_test.model.deploy("s3-integrator", "s3", channel="latest/stable"),

--- a/tests/integration/test_charm_ha_scaled.py
+++ b/tests/integration/test_charm_ha_scaled.py
@@ -40,7 +40,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
         # Secret must be at least 8 characters: https://github.com/canonical/minio-operator/issues/137
         ops_test.model.deploy(
             "minio",
-            channel="latest/stable",
+            channel="ckf-1.9/stable",
             config={"access-key": "access", "secret-key": "secretsecret"},
         ),
         ops_test.model.deploy("s3-integrator", "s3", channel="latest/stable"),

--- a/tests/integration/test_charm_monolithic.py
+++ b/tests/integration/test_charm_monolithic.py
@@ -40,7 +40,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
         # Secret must be at least 8 characters: https://github.com/canonical/minio-operator/issues/137
         ops_test.model.deploy(
             "minio",
-            channel="latest/stable",
+            channel="ckf-1.9/stable",
             config={"access-key": "access", "secret-key": "secretsecret"},
         ),
         ops_test.model.deploy("s3-integrator", "s3", channel="latest/stable"),


### PR DESCRIPTION
Pin minio charm in itests to "ckf-1.9/stable" track since `latest/stable` no longer exists
- fixes itests